### PR TITLE
Removes station_levels

### DIFF
--- a/code/_helpers/areas.dm
+++ b/code/_helpers/areas.dm
@@ -80,7 +80,7 @@
 	. = (A.z in z_levels)
 
 /proc/is_station_area(var/area/A)
-	. = isStationLevel(A.z)
+	. = is_main_level(A.z)
 
 /proc/is_contact_area(var/area/A)
 	. = isContactLevel(A.z)

--- a/code/_helpers/game.dm
+++ b/code/_helpers/game.dm
@@ -2,7 +2,7 @@
 
 /proc/max_default_z_level()
 	var/max_z = 0
-	for(var/z in GLOB.using_map.station_levels)
+	for(var/z in get_main_levels())
 		max_z = max(z, max_z)
 	for(var/z in GLOB.using_map.admin_levels)
 		max_z = max(z, max_z)
@@ -54,11 +54,12 @@
 
 	return heard
 
-/proc/isStationLevel(var/level)
-	return level in GLOB.using_map.station_levels
+/proc/is_main_level(var/level)
+	var/datum/scene/S = get_scene_from_z(level)
+	return (S && S.main_scene)
 
-/proc/isNotStationLevel(var/level)
-	return !isStationLevel(level)
+/proc/is_not_main_level(var/level)
+	return !is_main_level(level)
 
 /proc/isPlayerLevel(var/level)
 	return level in GLOB.using_map.player_levels
@@ -71,6 +72,9 @@
 
 /proc/isContactLevel(var/level)
 	return level in GLOB.using_map.contact_levels
+
+/proc/get_main_levels()
+	return SSmapping.main_scene.levels
 
 /proc/circlerange(center=usr,radius=3)
 

--- a/code/_helpers/text.dm
+++ b/code/_helpers/text.dm
@@ -576,3 +576,10 @@ proc/TextPreview(var/string,var/len=40)
 	var/where = "[A? A.name : "Unknown Location"] | [T.x], [T.y], [T.z]"
 	var/whereLink = "<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>[where]</a>"
 	return whereLink
+
+
+//Dumps an object into a string, so it can be written to disk and loaded later
+/proc/serialize(var/datum/thing)
+	var/savefile/s = new
+	s << thing
+	return s.ExportText()

--- a/code/_helpers/turfs.dm
+++ b/code/_helpers/turfs.dm
@@ -77,7 +77,7 @@
 	return !turf_contains_dense_objects(T)
 
 /proc/is_station_turf(var/turf/T)
-	return T && isStationLevel(T.z)
+	return T && is_main_level(T.z)
 
 /proc/has_air(var/turf/T)
 	return !!T.return_air()

--- a/code/controllers/evacuation/evacuation_pods.dm
+++ b/code/controllers/evacuation/evacuation_pods.dm
@@ -46,7 +46,7 @@
 	else
 		// Bluespace Jump
 		priority_announcement.Announce(replacetext(replacetext(GLOB.using_map.shuttle_leaving_dock, "%dock_name%", "[GLOB.using_map.dock_name]"),  "%ETA%", "[round(get_eta()/60,1)] minute\s"))
-		SetUniversalState(/datum/universal_state/bluespace_jump, arguments=list(GLOB.using_map.station_levels))
+		SetUniversalState(/datum/universal_state/bluespace_jump, arguments=list(get_main_levels()))
 
 /datum/evacuation_controller/starship/finish_evacuation()
 	..()

--- a/code/controllers/subsystems/initialization/persistence.dm
+++ b/code/controllers/subsystems/initialization/persistence.dm
@@ -27,7 +27,7 @@ SUBSYSTEM_DEF(persistence)
 	if(!A || (A.area_flags & AREA_FLAG_IS_NOT_PERSISTENT))
 		return
 
-	if((!T.z in GLOB.using_map.station_levels) || !initialized)
+	if((!is_main_level(T.z)) || !initialized)
 		return
 
 	if(!tracking_values[track_type])

--- a/code/controllers/subsystems/mapping.dm
+++ b/code/controllers/subsystems/mapping.dm
@@ -4,6 +4,8 @@ SUBSYSTEM_DEF(mapping)
 	flags = SS_NO_FIRE
 	var/map_index = 0 //This is incremented whenever a new map is created, and used to prevent namespace collisions
 
+	var/datum/scene/main_scene
+
 	var/list/map_templates = list()
 	var/list/space_ruins_templates = list()
 	var/list/exoplanet_ruins_templates = list()
@@ -20,6 +22,10 @@ SUBSYSTEM_DEF(mapping)
 	for (var/t in subtypesof(/datum/scene))
 		var/datum/scene/S = new t
 		all_scene_datums[S.id] = S
+
+		//There should be only one main scene.
+		if (S.main_scene)
+			src.main_scene = S
 
 	for (var/t in subtypesof(/datum/level))
 		var/datum/level/L = new t

--- a/code/game/antagonist/antagonist_print.dm
+++ b/code/game/antagonist/antagonist_print.dm
@@ -39,7 +39,7 @@
 	if(ply.current)
 		if(ply.current.stat == DEAD)
 			text += "died"
-		else if(isNotStationLevel(ply.current.z))
+		else if(is_not_main_level(ply.current.z))
 			text += "fled"
 		else
 			text += "survived"

--- a/code/game/gamemodes/endgame/nuclear_explosion/nuclear_explosion.dm
+++ b/code/game/gamemodes/endgame/nuclear_explosion/nuclear_explosion.dm
@@ -22,7 +22,7 @@
 	start_cinematic_intro()
 
 	var/turf/T = get_turf(explosion_source)
-	if(isStationLevel(T.z))
+	if(is_main_level(T.z))
 		to_world("<span class='danger'>The [station_name()] was destoyed by the nuclear blast!</span>")
 
 		dust_mobs(GetConnectedZlevels(T.z))

--- a/code/game/gamemodes/events.dm
+++ b/code/game/gamemodes/events.dm
@@ -16,7 +16,7 @@ var/hadevent    = 0
 
 /* // Haha, this is way too laggy. I'll keep the prison break though.
 	for(var/obj/machinery/light/L in world)
-		if(isNotStationLevel(L.z)) continue
+		if(is_not_main_level(L.z)) continue
 		L.flicker(50)
 
 	sleep(100)
@@ -25,7 +25,7 @@ var/hadevent    = 0
 		var/turf/T = get_turf(H)
 		if(!T)
 			continue
-		if(isNotStationLevel(T.z))
+		if(is_not_main_level(T.z))
 			continue
 		if(istype(H,/mob/living/carbon/human))
 			H.apply_damage((rand(15,75)),IRRADIATE, damage_flags = DAM_DISPERSED)

--- a/code/game/gamemodes/events/holidays/Christmas.dm
+++ b/code/game/gamemodes/events/holidays/Christmas.dm
@@ -1,6 +1,6 @@
 /proc/Christmas_Game_Start()
 	for(var/obj/structure/flora/tree/pine/xmas in world)
-		if(isNotStationLevel(xmas.z))	continue
+		if(is_not_main_level(xmas.z))	continue
 		for(var/turf/simulated/floor/T in orange(1,xmas))
 			for(var/i=1,i<=rand(1,5),i++)
 				new /obj/item/weapon/a_gift(T)

--- a/code/game/gamemodes/events/holidays/Holidays.dm
+++ b/code/game/gamemodes/events/holidays/Holidays.dm
@@ -171,7 +171,7 @@ var/global/Holiday = null
 */
 /*			var/list/obj/containers = list()
 			for(var/obj/item/weapon/storage/S in world)
-				if(isNotStationLevel(S.z))	continue
+				if(is_not_main_level(S.z))	continue
 				containers += S
 
 			message_admins("<span class='notice'>DEBUG: Event: Egg spawned at [Egg.loc] ([Egg.x],[Egg.y],[Egg.z])</span>")*/

--- a/code/game/gamemodes/events/wormholes.dm
+++ b/code/game/gamemodes/events/wormholes.dm
@@ -1,4 +1,4 @@
-/proc/wormhole_event(var/list/zlevels = GLOB.using_map.station_levels)
+/proc/wormhole_event(var/list/zlevels = get_main_levels())
 	spawn()
 		var/list/pick_turfs = list()
 		for(var/z in zlevels)

--- a/code/game/gamemodes/malfunction/newmalf_ability_trees/HELPERS.dm
+++ b/code/game/gamemodes/malfunction/newmalf_ability_trees/HELPERS.dm
@@ -175,7 +175,7 @@
 	for(var/obj/machinery/power/apc/A in SSmachines.machinery)
 		if(A.hacker && A.hacker == user)
 			continue
-		if(A.z in GLOB.using_map.station_levels)
+		if(A.z in get_main_levels())
 			station_apcs.Add(A)
 		else
 			offstation_apcs.Add(A)

--- a/code/game/gamemodes/meteor/meteor.dm
+++ b/code/game/gamemodes/meteor/meteor.dm
@@ -72,7 +72,7 @@
 		next_wave = round_duration_in_ticks + meteor_wave_delay
 		// Starts as barely noticeable dust impact, ends as barrage of most severe meteor types the code has to offer. Have fun.
 		spawn()
-			spawn_meteors(meteor_severity, get_meteor_types(), pick(GLOB.cardinal), pick(GLOB.using_map.station_levels))
+			spawn_meteors(meteor_severity, get_meteor_types(), pick(GLOB.cardinal), pick(get_main_levels()))
 		var/escalated = FALSE
 		if(prob(escalation_probability) && (meteor_severity < maximal_severity))
 			meteor_severity++

--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -251,7 +251,7 @@ mob/living/proc/near_camera()
 
 	if(. == TRACKING_NO_COVERAGE)
 		var/turf/T = get_turf(src)
-		if(T && (T.z in GLOB.using_map.station_levels) && hassensorlevel(src, SUIT_SENSOR_TRACKING))
+		if(T && (is_main_level(T.z)) && hassensorlevel(src, SUIT_SENSOR_TRACKING))
 			return TRACKING_POSSIBLE
 
 mob/living/proc/tracking_initiated()

--- a/code/game/machinery/nuclear_bomb.dm
+++ b/code/game/machinery/nuclear_bomb.dm
@@ -155,7 +155,7 @@ var/bomb_set
 		extended = 1
 		if(!src.lighthack)
 			flick("lock", src)
-			update_icon()	
+			update_icon()
 
 /obj/machinery/nuclearbomb/interface_interact(mob/user as mob)
 	if(extended && !panel_open)
@@ -376,7 +376,7 @@ var/bomb_set
 		GLOB.moved_event.unregister(src, src, /obj/item/weapon/disk/nuclear/proc/check_z_level) // However, when we are certain unregister if necessary
 		return
 	var/turf/T = get_turf(src)
-	if(!T || isNotStationLevel(T.z))
+	if(!T || is_not_main_level(T.z))
 		qdel(src)
 
 /obj/item/weapon/disk/nuclear/Destroy()

--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -77,7 +77,7 @@
 	if(istype(A, /area/space))
 		return AREA_SPACE
 
-	if(A.z in GLOB.using_map.station_levels)
+	if(is_main_level(A.z))
 		return AREA_STATION
 
 	return AREA_SPECIAL

--- a/code/modules/admin/verbs/diagnostics.dm
+++ b/code/modules/admin/verbs/diagnostics.dm
@@ -17,7 +17,7 @@
 	var/inactive_on_main_station = 0
 	for(var/zone/zone in SSair.zones)
 		var/turf/simulated/turf = locate() in zone.contents
-		if(turf && turf.z in GLOB.using_map.station_levels)
+		if(turf && is_main_level(turf.z))
 			if(zone.needs_update)
 				active_on_main_station++
 			else

--- a/code/modules/events/computer_update.dm
+++ b/code/modules/events/computer_update.dm
@@ -12,7 +12,7 @@
 			updates_to_install = rand(500000, 1000000)
 
 	for(var/obj/item/modular_computer/C in SSobj.processing)
-		if((C.z in GLOB.using_map.station_levels))
+		if((is_main_level(C.z)))
 			var/datum/extension/interactive/ntos/os = get_extension(src, /datum/extension/interactive/ntos)
 			if(os && os.get_ntnet_status() && os.receives_updates)
 				os.updates = updates_to_install

--- a/code/modules/events/event.dm
+++ b/code/modules/events/event.dm
@@ -155,7 +155,7 @@
 	startedAt = world.time
 
 	if(!affecting_z)
-		affecting_z = GLOB.using_map.station_levels
+		affecting_z = get_main_levels()
 
 	setup()
 	..()

--- a/code/modules/events/meteors.dm
+++ b/code/modules/events/meteors.dm
@@ -31,7 +31,7 @@
 	// Begin sending the alarm signals to shield diffusers so the field is already regenerated (if it exists) by the time actual meteors start flying around.
 	if(alarmWhen < activeFor)
 		for(var/obj/machinery/shield_diffuser/SD in SSmachines.machinery)
-			if(isStationLevel(SD.z))
+			if(is_main_level(SD.z))
 				SD.meteor_alarm(10)
 
 	if(waves && activeFor >= next_meteor)
@@ -130,7 +130,7 @@
 		. = round(. * 0.5)
 	if(speed > SHIP_SPEED_FAST) //Sanic stahp
 		. *= 2
-	
+
 	//Smol ship evasion
 	if(victim.vessel_size < SHIP_SIZE_LARGE && speed < SHIP_SPEED_FAST)
 		var/skill_needed = SKILL_PROF

--- a/code/modules/hydroponics/trays/tray_soil.dm
+++ b/code/modules/hydroponics/trays/tray_soil.dm
@@ -54,7 +54,7 @@
 	connected_zlevels = GetConnectedZlevels(z)
 
 /obj/machinery/portable_atmospherics/hydroponics/soil/invisible/Process()
-	if(z in GLOB.using_map.station_levels) //plants on station always tick
+	if(is_main_level(z)) //plants on station always tick
 		return ..()
 	if(living_observers_present(connected_zlevels))
 		return ..()

--- a/code/modules/mob/living/silicon/ai/malf.dm
+++ b/code/modules/mob/living/silicon/ai/malf.dm
@@ -74,7 +74,7 @@
 
 	// Off-Station APCs should not count towards CPU generation.
 	for(var/obj/machinery/power/apc/A in hacked_apcs)
-		if(A.z in GLOB.using_map.station_levels)
+		if(is_main_level(A.z))
 			cpu_gain += 0.004 * (hacked_apcs_hidden ? 0.5 : 1)
 			cpu_storage += 10
 

--- a/code/modules/modular_computers/hardware/network_card.dm
+++ b/code/modules/modular_computers/hardware/network_card.dm
@@ -89,7 +89,7 @@ var/global/ntnet_card_uid = 1
 	var/turf/T = get_turf(src)
 	if(!istype(T)) //no reception in nullspace
 		return
-	if(T.z in GLOB.using_map.station_levels)
+	if(is_main_level(T.z))
 		// Computer is on station. Low/High signal depending on what type of network card you have
 		. = strength
 	else if(T.z in GLOB.using_map.contact_levels) //not on station, but close enough for radio signal to travel
@@ -105,7 +105,7 @@ var/global/ntnet_card_uid = 1
 		var/obj/item/weapon/stock_parts/computer/network_card/network_card = comp.get_component(PART_NETWORK)
 		if(network_card)
 			. = min(., network_card.get_signal(specific_action, routed_through))
-		
+
 /obj/item/weapon/stock_parts/computer/network_card/on_disable()
 	ntnet_global.unregister(identification_id)
 

--- a/code/modules/multiz/scene.dm
+++ b/code/modules/multiz/scene.dm
@@ -17,6 +17,9 @@
 	var/list/level_numbers = list()
 		//This is a NON associative list containing only the raw z numbers of zlevels which are in this scene
 
+	var/main_scene = FALSE
+		//If true, this is the main station/ship/colony that the game revolves around. Only one scene should have this
+
 /*--------------------------------------------------------------------------------------------------------------
 
 	Helper Procs:

--- a/code/modules/overmap/README.dm
+++ b/code/modules/overmap/README.dm
@@ -37,7 +37,6 @@ If this zlevel (or any of connected ones for multiz) doesn't have this object, y
 2. Put it anywhere on the ship/sector map. It will do the rest on its own during init.
 If your thing is multiz, only one is needed per multiz sector/ship.
 
-If it's player's main base (e.g Exodus), set 'base' var to 1, so it adds itself to station_levels list.
 If this place cannot be reached or left with EVA, set 'in_space' var to 0
 If you want exploration shuttles (look below) to be able to dock here, set up waypoints lists.
 generic_waypoints is list of landmark_tags of waypoints any shttle should be able to visit.

--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -64,7 +64,6 @@
 	if(!in_space)
 		GLOB.using_map.sealed_levels |= map_z
 	if(base)
-		GLOB.using_map.station_levels |= map_z
 		GLOB.using_map.contact_levels |= map_z
 		GLOB.using_map.map_levels |= map_z
 

--- a/code/modules/persistence/persistence_datum.dm
+++ b/code/modules/persistence/persistence_datum.dm
@@ -73,7 +73,7 @@
 			return
 
 	var/_z = tokens["z"]
-	if(_z in GLOB.using_map.station_levels)
+	if(is_main_level(_z))
 		. = GetValidTurf(locate(tokens["x"], tokens["y"], _z), tokens)
 		if(.)
 			CreateEntryInstance(., tokens)
@@ -84,7 +84,7 @@
 	if(GetEntryAge(entry) >= entries_expire_at)
 		return FALSE
 	var/turf/T = get_turf(entry)
-	if(!T || !(T.z in GLOB.using_map.station_levels) )
+	if(!T || !is_main_level(T.z) )
 		return FALSE
 	var/area/A = get_area(T)
 	if(!A || (A.area_flags & AREA_FLAG_IS_NOT_PERSISTENT))

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -301,7 +301,7 @@
 			GLOB.using_map.unbolt_saferooms() // torch
 			for(var/mob/M in GLOB.player_list)
 				var/turf/T = get_turf(M)
-				if(T && (T.z in GLOB.using_map.station_levels) && !istype(M,/mob/new_player) && !isdeaf(M))
+				if(T && (is_main_level(T.z)) && !istype(M,/mob/new_player) && !isdeaf(M))
 					sound_to(M, 'sound/ambience/matteralarm.ogg')
 		else if(safe_warned && public_alert)
 			GLOB.global_announcer.autosay(alert_msg, "Supermatter Monitor")
@@ -319,14 +319,14 @@
 
 	if(damage > explosion_point)
 		if(!exploded)
-			if(!istype(L, /turf/space) && (L.z in GLOB.using_map.station_levels))
+			if(!istype(L, /turf/space) && (is_main_level(L.z)))
 				announce_warning()
 			explode()
 	else if(damage > warning_point) // while the core is still damaged and it's still worth noting its status
 		shift_light(5, warning_color)
 		if(damage > emergency_point)
 			shift_light(7, emergency_color)
-		if(!istype(L, /turf/space) && ((world.timeofday - lastwarning) >= WARNING_DELAY * 10) && (L.z in GLOB.using_map.station_levels))
+		if(!istype(L, /turf/space) && ((world.timeofday - lastwarning) >= WARNING_DELAY * 10) && (is_main_level(L.z)))
 			announce_warning()
 	else
 		shift_light(4,initial(light_color))

--- a/code/unit_tests/map_tests.dm
+++ b/code/unit_tests/map_tests.dm
@@ -515,7 +515,7 @@ datum/unit_test/ladder_check/start_test()
 /datum/unit_test/station_pipes_shall_not_leak/start_test()
 	var/failures = 0
 	for(var/obj/machinery/atmospherics/pipe/P in world)
-		if(P.leaking && isStationLevel(P.z))
+		if(P.leaking && is_main_level(P.z))
 			failures++
 			log_bad("Following pipe is leaking: [log_info_line(P)]")
 
@@ -539,7 +539,7 @@ datum/unit_test/ladder_check/start_test()
 			log_bad("Nullspace terminal : [log_info_line(term)]")
 			continue
 
-		if(!isStationLevel(T.z))
+		if(!is_main_level(T.z))
 			continue
 
 		var/found_cable = FALSE
@@ -601,7 +601,7 @@ datum/unit_test/ladder_check/start_test()
 		return FALSE
 
 	// We don't care about non-station wires
-	if(!isStationLevel(source_turf.z))
+	if(!is_main_level(source_turf.z))
 		return TRUE
 
 	for(var/dir in list(C.d1, C.d2))

--- a/maps/away_sites_testing/away_sites_testing_define.dm
+++ b/maps/away_sites_testing/away_sites_testing_define.dm
@@ -3,8 +3,6 @@
 	name = "Away Sites Testing"
 	full_name = "Away Sites Testing Land"
 	path = "away_sites_testing"
-
-	station_levels = list()
 	contact_levels = list()
 	player_levels = list()
 

--- a/maps/bearcat/bearcat_scene.dm
+++ b/maps/bearcat/bearcat_scene.dm
@@ -4,6 +4,7 @@
 	//------------------
 	name = "FTV Bearcat" //The name of the location. This may be shown in interfaces and should be human-readable
 	id = "ftv_bearcat"	  //ID must be unique, landmarks will use it to link levels to this scene datum
+	main_scene = TRUE
 
 //Base type of level, this one won't be instantiated but subtypes will
 /datum/level/bearcat

--- a/maps/example/example_define.dm
+++ b/maps/example/example_define.dm
@@ -6,7 +6,7 @@
 	lobby_screens = list('maps/example/lobby.png')
 	lobby_tracks = list(/music_track/absconditus)
 
-	station_levels = list(1, 2, 3)
+	station_levels = list(1, 2, 3) //TODO: Update this example map at some point, to use landmarks/scenes/levels instead of station_levels
 	contact_levels = list(1, 2, 3)
 	player_levels = list(1, 2, 3)
 

--- a/maps/torch/items/explo_shotgun.dm
+++ b/maps/torch/items/explo_shotgun.dm
@@ -27,16 +27,12 @@
 	else
 		icon_state = "ghettexpshotgun[!!chambered]"
 	..()
-	
+
 /obj/item/weapon/gun/projectile/shotgun/pump/exploration/Destroy()
 	QDEL_NULL(reinforced)
 	. = ..()
-	
-/obj/item/weapon/gun/projectile/shotgun/pump/exploration/free_fire()
-	var/my_z = get_z(src)
-	if(!GLOB.using_map.station_levels.Find(my_z))
-		return TRUE
-	return ..()
+
+
 
 /obj/item/weapon/gun/projectile/shotgun/pump/exploration/attackby(obj/item/I, mob/user)
 	if(!reinforced && istype(I, /obj/item/pipe) && user.unEquip(I, src))

--- a/maps/torch/torch_scene.dm
+++ b/maps/torch/torch_scene.dm
@@ -4,6 +4,7 @@
 	//------------------
 	name = "SEV Torch" //The name of the location. This may be shown in interfaces and should be human-readable
 	id = "sev_torch"	  //ID must be unique, landmarks will use it to link levels to this scene datum
+	main_scene = TRUE
 
 //Base type of level, this one won't be instantiated but subtypes will
 /datum/level/torch


### PR DESCRIPTION
standardises checks for if a level is on the ship, renames station_levels to main levels, and updates the code appropriately

some legacy level lists still exist in map dm files, kept for the data, but they dont do anything now